### PR TITLE
style: Remove unintended focus outline on Sidebar

### DIFF
--- a/src/docs/src/lib/Sidebar.svelte
+++ b/src/docs/src/lib/Sidebar.svelte
@@ -52,16 +52,14 @@
         use:clickOutsideWrapper={handleClickOutside}
         {id}
         {...$$restProps}
-        class="sidebar overflow-y-auto z-50 px-4 pb-4 border-x border-violet-500 w-60 fixed inset-y-0 left-0"
+        class="sidebar overflow-y-auto z-50 px-4 pb-4 w-60 fixed inset-y-0 left-0"
         transition:multiple={transitionParams}
-        tabindex="-1"
         aria-modal="true"
         role="dialog"
         aria-controls={id}
         aria-labelledby={id}
     >
         <div
-            tabindex="-1"
             aria-hidden={hidden}
             on:keydown={(e) => {
                 if (e.key === 'Escape') hidden = true;


### PR DESCRIPTION
## Description
Removed `tabindex="-1"` from the app's main wrapper div, which was causing a `:focus` outline 
and minor layout shifts. 

Interactive elements (buttons, nav items) inside the sidebar are confirmed fully functional by click and <Tab> navigation.

Removed leftover debugging CSS (`border-x border-violet-500`) from the sidebar component.

## Screenshots
**Before**
<img width="271" height="405" alt="image" src="https://github.com/user-attachments/assets/d71a7120-dd4e-4dcc-ae85-9b8322c62bc0" />

**After**
<img width="267" height="407" alt="image" src="https://github.com/user-attachments/assets/5d8fc238-49a8-49c4-aadf-e17f6a292ba3" />



### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing guide](../CONTRIBUTING.md)
- [x] Include a description of the changes made in the PR description and in the commit messages.
- [x] Include screenshots/videos of the changes made.
- [x] Verify that the linter and tests are passing, with `npm run lint` and `npm run test`.
